### PR TITLE
GAL-407: fix ungraceful shutdown causing left over lock files

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
 
 - name: Create lodestar user
   user:
-    comment:  lodestar client user
+    comment: lodestar client user
     name: "{{ lodestar_user }}"
     group: "{{ lodestar_group }}"
   become: true
@@ -22,7 +22,7 @@
     group: "{{ lodestar_group }}"
   loop:
     - "{{ lodestar_base_dir }}"
-    - "{{ lodestar_config_dir }}"    
+    - "{{ lodestar_config_dir }}"
     - "{{ lodestar_data_dir }}"
     - "{{ lodestar_log_dir }}"
   become: true
@@ -36,8 +36,9 @@
 - name: Stop lodestar
   community.docker.docker_compose:
     project_src: "{{ lodestar_base_dir }}"
+    build: false
+    stopped: true
     state: absent
-  ignore_errors: yes    
 
 - name: Create docker-compose.yml file
   template:
@@ -57,8 +58,9 @@
     state: present
   become: yes
 
-- name: Restart lodestar
+- name: Restart services
   community.docker.docker_compose:
     project_src: "{{ lodestar_base_dir }}"
+    build: false
     restarted: true
     state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -58,7 +58,7 @@
     state: present
   become: yes
 
-- name: Restart services
+- name: Start services
   community.docker.docker_compose:
     project_src: "{{ lodestar_base_dir }}"
     build: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -62,5 +62,4 @@
   community.docker.docker_compose:
     project_src: "{{ lodestar_base_dir }}"
     build: false
-    restarted: true
     state: present

--- a/templates/lodestar-compose.yml.j2
+++ b/templates/lodestar-compose.yml.j2
@@ -56,6 +56,7 @@ services:
   lodestar-validator:
     container_name: lodestar-validator
     image: "{{ lodestar_image }}:{{ lodestar_version }}"
+    stop_grace_period: 1m30s
     restart: always
 {% if lodestar_validator_network_mode == "host" %}
     network_mode: "{{ lodestar_validator_network_mode }}"

--- a/templates/lodestar-compose.yml.j2
+++ b/templates/lodestar-compose.yml.j2
@@ -57,7 +57,7 @@ services:
     container_name: lodestar-validator
     image: "{{ lodestar_image }}:{{ lodestar_version }}"
     stop_grace_period: 1m30s
-    restart: always
+    restart: unless-stopped
 {% if lodestar_validator_network_mode == "host" %}
     network_mode: "{{ lodestar_validator_network_mode }}"
 {% endif %}


### PR DESCRIPTION
- Initial shutdown is graceful but the restart causes an ungraceful stop and start
- Instead, we only start and do not restart after we gracefully shut down